### PR TITLE
Build settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: scala
+scala:
+  - 2.11.12
+  - 2.12.7
+jdk:
+  - oraclejdk8
+  - openjdk11
+script:
+  - sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,14 @@
-
-scalaVersion := "2.11.8"
-
+scalaVersion := "2.11.12"
+crossScalaVersions := Seq("2.12.6", "2.11.12")
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
-
 crossPaths := false
-
 organization := "com.m3.play2"
-
 name := "play2-sentry"
-
 version := "2.0.1-SNAPSHOT"
-
 libraryDependencies ++= Seq(
-  "io.sentry" % "sentry-logback" % "1.7.5",
-  "com.typesafe.play" % "play_2.11" % "2.4.11" % "provided"
+  "io.sentry"         %  "sentry-logback" % "1.7.5",
+  "com.typesafe.play" %% "play"           % "2.4.11" % "provided"
 )
-
 publishTo := version { v: String =>
   sys.env.get("REPOSITORY_URL").map { base =>
     if (v.trim.endsWith("SNAPSHOT"))
@@ -24,6 +17,4 @@ publishTo := version { v: String =>
       "releases" at base + "libs-releases"
   }
 }.value
-
 resolvers += Resolver.typesafeRepo("releases")
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3


### PR DESCRIPTION
readme 日本語なので日本語で。

* sbt 1.2.3 が最新
* 最近の build.sbt は空行なくてもよい
* まだ全部 2.11 なのかもしれませんが、一応 Play 2.4 は Scala 2.11 と 2.12 に対応しているのでリリースできるよう crossScalaVersions を追加
* pull request がきてもいいように Travis の設定を追加（この PR を merge する前に TravisCI の設定画面から有効にしておいてください > https://travis-ci.org/m3dev/play2-sentry
* 将来の移行を見越して OpenJDK 11 を Travis build 対象にしてあります
