### PR TITLE
add tag-release feature

### DIFF
--- a/.github/decodekey.sh
+++ b/.github/decodekey.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "$PGP_SECRET" | base64 --decode | gpg --batch --import

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+on:
+  push:
+    tags: [ "*" ]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Scala
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+      - run: .github/decodekey.sh && sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,45 @@
-# .gitignore
+# Created by https://www.toptal.com/developers/gitignore/api/scala,sbt,playframework
+# Edit at https://www.toptal.com/developers/gitignore?templates=scala,sbt,playframework
 
-/.idea/
-/.env
+### PlayFramework ###
+# Ignore Play! working directory #
+bin/
+/db
+.eclipse
+/lib/
+/logs/
+/modules
+/project/project
+/project/target
+/target
+tmp/
+test-result
+server.pid
+*.eml
+/dist/
+.cache
+
+### SBT ###
+# Simple Build Tool
+# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
+
+dist/*
 target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.lib/
 
+### SBT Patch ###
+.bsp/
+
+### Scala ###
+*.class
+*.log
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# End of https://www.toptal.com/developers/gitignore/api/scala,sbt,playframework

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ Play2では、Java Servletとは違う独自の構造でHTTPリクエスト情�
 
 1. Playアプリの依存に追加する
 
-```
+```scala
 libraryDependencies ++= Seq(
-    "com.m3.play2" % "play2-sentry" % "1.0.0-SNAPSHOT"
+  "com.m3.play2" % "play2-sentry" % "1.0.0"
 )
 ```
 
 2. sentry設定でfactoryを指定する
 
 **sentry.properties**
-```
+```properties
 factory=com.m3.play2.sentry.PlaySentryFactory
 ```
 
@@ -37,7 +37,7 @@ factory=com.m3.play2.sentry.PlaySentryFactory
 
 **application.conf**
 
-```
+```hocon
 play {
   akka {
     actor {
@@ -52,7 +52,7 @@ play {
 
 4. HTTPフィルタにSentryLoggingFilterを追加
 
-```
+```scala
 import com.m3.play2.sentry.SentryLoggingFilter
 
 class ApplicationComponents(context: Context) extends BuiltInComponentsFromContext(context) {
@@ -65,7 +65,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
 
 5. Sentryの標準的な導入設定を行う
 
-参考: https://docs.sentry.io/clients/java/
+参考: https://docs.sentry.io/platforms/java/legacy/
 
    * ログ出力設定でSentryAppenderを指定する
    * アプリケーション固有のパッケージ名を明記
@@ -77,23 +77,23 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
 
 ### ビルド
 
-```
-$ sbt package
+```shell
+sbt package
 ```
 
 ### ローカル環境での動作確認
 
 1. モジュールをivyのローカルキャッシュにインストールする
 
-```
-$ sbt publishLocal
+```shell
+sbt publishLocal
 ```
 
 2. 動作確認用Playアプリで、resolvers にローカルキャッシュディレクトリを追加する
 
 **build.sbt**
 
-```
+```scala
 resolvers += "MyLocalIvy" at "file://"+Path.userHome.absolutePath+"/.ivy2/local"
 ```
 
@@ -102,12 +102,6 @@ resolvers += "MyLocalIvy" at "file://"+Path.userHome.absolutePath+"/.ivy2/local"
 4. アプリを実行する
 
 
-### artifactory にデプロイ
+### デプロイ
 
-以下のコマンドでartifactoryにjarを登録します
-
-```
-$ export REPOSITORY_URL={{デプロイ先のartifactoryのURL}}
-$ sbt clean package publish
-```
-
+`v` から始まる名前のタグをプッシュすると、GitHub Action により Central Repository に登録されます。

--- a/build.sbt
+++ b/build.sbt
@@ -1,29 +1,24 @@
-
-scalaVersion := "2.13.2"
-
-javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
-
-crossPaths := false
-
-organization := "com.m3.play2"
-
-name := "play2-sentry"
-
-version := "3.0.1-SNAPSHOT"
-
-libraryDependencies ++= Seq(
-  "io.sentry" % "sentry-logback" % "1.7.5",
-  "com.typesafe.play" % "play_2.13" % "2.8.2" % "provided"
-)
-
-publishTo := version { v: String =>
-  sys.env.get("REPOSITORY_URL").map { base =>
-    if (v.trim.endsWith("SNAPSHOT"))
-      "snapshots" at base + "libs-snapshots"
-    else
-      "releases" at base + "libs-releases"
-  }
-}.value
-
-resolvers += Resolver.typesafeRepo("releases")
-
+lazy val root = (project in file("."))
+  .settings(
+    organization := "com.m3.play2",
+    name := "play2-sentry",
+    scalaVersion := "2.13.10",
+      libraryDependencies ++= Seq(
+      "io.sentry" % "sentry-logback" % "1.7.30",
+      "com.typesafe.play" %% "play" % "2.8.19" % Provided
+    )
+  )
+  .settings(
+    homepage := Some(url("https://github.com/m3dev/play2-sentry")),
+    licenses := Seq(
+      "The MIT License" -> url("https://opensource.org/licenses/mit-license.php")
+    ),
+    developers := List(
+      Developer(
+        "kijuky",
+        "Kizuki YASUE",
+        "kizuki-yasue@m3.com",
+        url("https://github.com/kijuky")
+      )
+    )
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,2 @@
+versionScheme := Some("early-semver")
+version := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
GitHub Action によるタグ付けリリース機能を追加します。 for fix #2 

タグ付けリリースについてはこちらを参照

- https://eed3si9n.com/ja/auto-publish-sbt-plugin-from-github-actions
- https://github.com/sbt/sbt-ci-release

# 必要になる環境変数

- PGP_PASSPHRASE
- PGP_SECRET
- SONATYPE_PASSWORD
- SONATYPE_USERNAME

# 後でやる

- [ ] 環境変数がセットされたら、試しに `v3.0.0-SNAPSHOT` とか設定して GitHub Action が動くかどうかを確認する。

# 後で確認

ホスト名が `oss.sonatype.org` と異なる場合は build.sbt に追加で下記の設定が必要

```build.sbt
sonatypeCredentialHost := "s01.oss.sonatype.org" // 大体は s01 がついている
```